### PR TITLE
Adjust status section to fit fullscreen layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         }
 
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'Meiryo', system-ui, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #982eff 100%);
             color: white;
             height: 100dvh;
@@ -154,28 +154,28 @@
         }
         .section-title-text { white-space: nowrap; }
 
-        .summary-wrapper { display: flex; gap: var(--pad-4); align-items: stretch; flex-wrap: nowrap; overflow-x: auto; }
+        .summary-wrapper { display: flex; gap: var(--pad-4); align-items: stretch; flex-wrap: wrap; row-gap: var(--pad-3); }
 
         .status-section {
-            flex: 1 1 0;
-            min-width: 0;
+            flex: 1 1 18rem;
+            min-width: min(100%, calc(32 * var(--v)));
             display: none;
             flex-direction: column;
             background: rgba(255, 255, 255, 0.12);
             border-radius: var(--radius-l);
-            padding: var(--pad-3);
+            padding: clamp(var(--pad-2), 2.5vw, var(--pad-3));
             box-shadow: 0 calc(2 * var(--v)) calc(8 * var(--v)) rgba(0, 0, 0, 0.1);
-            gap: calc(2 * var(--v));
+            gap: calc(1.5 * var(--v));
         }
         .status-section.active { display: flex; }
         .status-title { font-size: calc(4 * var(--v)); font-weight: bold; text-align: center; margin-bottom: var(--pad-1); }
 
-        .status-rows { display: grid; flex: 1 1 auto; min-height: 0; grid-template-rows: repeat(4, 1fr); gap: calc(2 * var(--v)); }
+        .status-rows { display: grid; flex: 1 1 auto; min-height: 0; grid-template-rows: repeat(4, 1fr); gap: calc(1.5 * var(--v)); }
         .status-row {
             display: flex;
             align-items: center;
             justify-content: center;
-            padding: calc(2 * var(--v)) calc(2.5 * var(--v));
+            padding: calc(1.6 * var(--v)) calc(2 * var(--v));
             border-radius: calc(3.5 * var(--v));
             background: rgba(255, 255, 255, 0.1);
             height: 100%;
@@ -191,14 +191,14 @@
             align-items: center;
             column-gap: calc(3 * var(--v));
             width: 100%;
-            --status-switch-width: clamp(11rem, 22vw, 18rem);
-            --status-switch-height: clamp(calc(var(--vh-adjusted) * 3.4), 3rem, calc(var(--vh-adjusted) * 5));
-            --status-switch-padding-inline: clamp(1rem, 1.5vw, 2.2rem);
+            --status-switch-width: clamp(9.5rem, 24vw, 18rem);
+            --status-switch-height: clamp(calc(var(--vh-adjusted) * 2.6), 2.2rem, calc(var(--vh-adjusted) * 4.4));
+            --status-switch-padding-inline: clamp(0.85rem, 1.35vw, 1.9rem);
             --status-switch-thumb-gap-inline: calc(var(--status-switch-height) * 0.12);
             --status-switch-thumb-gap-block: calc(var(--status-switch-height) * 0.1);
-            --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 1.35), calc(1rem + 0.55vw), calc(var(--vh-adjusted) * 2.3));
-            --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 1.25), calc(0.9rem + 0.5vw), calc(var(--vh-adjusted) * 2));
-            --status-state-text-font: clamp(calc(var(--vh-adjusted) * 1.2), calc(0.9rem + 0.45vw), calc(var(--vh-adjusted) * 1.9));
+            --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 1.05), calc(0.9rem + 0.4vw), calc(var(--vh-adjusted) * 2.1));
+            --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 0.95), calc(0.8rem + 0.35vw), calc(var(--vh-adjusted) * 1.8));
+            --status-state-text-font: clamp(calc(var(--vh-adjusted) * 0.95), calc(0.8rem + 0.35vw), calc(var(--vh-adjusted) * 1.8));
             cursor: pointer;
             user-select: none;
             -webkit-user-select: none;
@@ -393,7 +393,7 @@
             align-items: center;
             background: rgba(255, 255, 255, 0.1);
             border-radius: calc(2.5 * var(--v));
-            padding: calc(2 * var(--v)) calc(1.5 * var(--v));
+            padding: calc(1.6 * var(--v)) calc(1.2 * var(--v));
             flex: none;
             margin: var(--pad-1) 0;
         }
@@ -436,7 +436,7 @@
         .score-btn:active { transform: translateY(calc(0.5 * var(--v))); box-shadow: 0 calc(0.5 * var(--v)) calc(2 * var(--v)) rgba(0,0,0,0.7); }
 
         .summary-section {
-            flex: 1 1 0; min-width: 0; height: auto; background: rgba(255, 255, 255, 0.15); backdrop-filter: blur(calc(3.5 * var(--v)));
+            flex: 1 1 18rem; min-width: min(100%, calc(32 * var(--v))); height: auto; background: rgba(255, 255, 255, 0.15); backdrop-filter: blur(calc(3.5 * var(--v)));
             border-radius: var(--radius-l); padding: var(--pad-3); display: flex; flex-direction: column; box-shadow: 0 calc(2 * var(--v)) calc(8 * var(--v)) rgba(0, 0, 0, 0.1);
         }
         .summary-header { display: flex; align-items: center; gap: var(--pad-3); margin-bottom: var(--pad-3); }
@@ -501,7 +501,14 @@
 
         @media screen and (max-width: 900px) {
             .summary-wrapper {
-                overflow-x: auto;
+                flex-direction: column;
+                overflow-x: visible;
+            }
+
+            .summary-section,
+            .status-section {
+                flex: 1 1 100%;
+                min-width: 100%;
             }
         }
 
@@ -532,19 +539,19 @@
             }
 
             .status-section {
-                padding: 10px;
-                gap: 8px;
+                padding: clamp(8px, 2vw, 12px);
+                gap: 6px;
             }
 
             .status-toggle {
-                --status-switch-width: clamp(10rem, 20vw, 16rem);
-                --status-switch-height: clamp(calc(var(--vh-adjusted) * 3.1), 2.8rem, calc(var(--vh-adjusted) * 4.6));
-                --status-switch-padding-inline: clamp(0.9rem, 1.4vw, 1.8rem);
+                --status-switch-width: clamp(8.5rem, 22vw, 16rem);
+                --status-switch-height: clamp(calc(var(--vh-adjusted) * 2.3), 2rem, calc(var(--vh-adjusted) * 4));
+                --status-switch-padding-inline: clamp(0.75rem, 1.2vw, 1.6rem);
                 --status-switch-thumb-gap-inline: calc(var(--status-switch-height) * 0.12);
                 --status-switch-thumb-gap-block: calc(var(--status-switch-height) * 0.1);
-                --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 1.15), calc(0.9rem + 0.4vw), calc(var(--vh-adjusted) * 1.9));
-                --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 1.05), calc(0.8rem + 0.35vw), calc(var(--vh-adjusted) * 1.6));
-                --status-state-text-font: clamp(calc(var(--vh-adjusted) * 1.05), calc(0.8rem + 0.35vw), calc(var(--vh-adjusted) * 1.6));
+                --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 0.95), calc(0.85rem + 0.3vw), calc(var(--vh-adjusted) * 1.8));
+                --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 0.85), calc(0.75rem + 0.28vw), calc(var(--vh-adjusted) * 1.55));
+                --status-state-text-font: clamp(calc(var(--vh-adjusted) * 0.85), calc(0.75rem + 0.28vw), calc(var(--vh-adjusted) * 1.55));
             }
             
             .player-row {
@@ -621,8 +628,8 @@
             }
 
             .status-section {
-                padding: 8px;
-                gap: 6px;
+                padding: 6px;
+                gap: 5px;
             }
 
             .status-switch-option {
@@ -630,14 +637,14 @@
             }
 
             .status-toggle {
-                --status-switch-width: clamp(9rem, 24vw, 14rem);
-                --status-switch-height: clamp(calc(var(--vh-adjusted) * 2.8), 2.4rem, calc(var(--vh-adjusted) * 4));
-                --status-switch-padding-inline: clamp(0.8rem, 1.2vw, 1.5rem);
+                --status-switch-width: clamp(8rem, 26vw, 13rem);
+                --status-switch-height: clamp(calc(var(--vh-adjusted) * 2.1), 1.8rem, calc(var(--vh-adjusted) * 3.4));
+                --status-switch-padding-inline: clamp(0.65rem, 1vw, 1.3rem);
                 --status-switch-thumb-gap-inline: calc(var(--status-switch-height) * 0.12);
                 --status-switch-thumb-gap-block: calc(var(--status-switch-height) * 0.1);
-                --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 1.0), calc(0.85rem + 0.32vw), calc(var(--vh-adjusted) * 1.6));
-                --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 0.9), calc(0.75rem + 0.28vw), calc(var(--vh-adjusted) * 1.45));
-                --status-state-text-font: clamp(calc(var(--vh-adjusted) * 0.9), calc(0.75rem + 0.28vw), calc(var(--vh-adjusted) * 1.45));
+                --status-toggle-text-font: clamp(calc(var(--vh-adjusted) * 0.9), calc(0.8rem + 0.26vw), calc(var(--vh-adjusted) * 1.45));
+                --status-switch-option-font: clamp(calc(var(--vh-adjusted) * 0.8), calc(0.7rem + 0.24vw), calc(var(--vh-adjusted) * 1.35));
+                --status-state-text-font: clamp(calc(var(--vh-adjusted) * 0.8), calc(0.7rem + 0.24vw), calc(var(--vh-adjusted) * 1.35));
             }
             
             .section-title {
@@ -713,11 +720,20 @@
             }
             
             .personal-section, .multi-player-section {
-                height: 74%;
+                height: auto;
             }
-            
+
+            .summary-wrapper {
+                flex-direction: column;
+            }
+
+            .summary-section,
+            .status-section {
+                min-width: 100%;
+            }
+
             .summary-section {
-                height: 26%;
+                height: auto;
                 padding: 6px;
             }
             


### PR DESCRIPTION
## Summary
- reduce spacing and typography in the rescue/out status switches so the layout can scale to the viewport
- allow the summary and status columns to wrap vertically on narrow displays and align their minimum widths
- tune responsive breakpoints so small screens keep the interface within the fullscreen viewport
- specify a Japanese sans-serif font stack so the 生還/脱落 記録 heading renders with the expected glyphs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e47cd060708328a639a177caba12f2